### PR TITLE
feat(thesis-template): adjust language settings and expand content

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_20" project-jdk-name="TeX Live SDK" project-jdk-type="TeX Live SDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/chapters/BPP/einleitung.tex
+++ b/chapters/BPP/einleitung.tex
@@ -1,10 +1,30 @@
 \chapter{Projektbeschreibung}
 \label{ch:description}
-blablabla
+Der Titel des Projekts lautet \enquote{Automatische DNS-Zonen und Eintragsverwaltung in einer verteilten Multi-Cloud-Microservice-Architektur} und wird im Folgenden beschrieben.
+Diese Arbeit soll sich auf das Kernthema der automatischen DNS-Zonen und Eintragsverwaltung in einer verteilten Multi-Cloud-Microservice-Architektur konzentrieren und nicht auf die Implementierung der Microservices selbst.
+Weiterhin werden verwendete Technologien welche nicht direkt mit dem Kernthema in Verbindung stehen nur oberflächlich beschrieben.
 
 \section{Idee}
 \label{sec:description:projektidee}
-blablabla
+Die Projektidee entstand aus dem Bedarf der Prozesstrennung und Automatisierung zwischen den Abteilungen der Entwicklung und dem Betrieb.
+Die Abteilung des Betriebs besteht aus \ac{DevOps}, welche sich um die Entwicklung und Bereitstellung von Infrastruktur kümmern.
+Die Abteilungen der Entwickler beschäftigen sich mit der Entwicklung von Microservices und der Bereitstellung dieser auf der Infrastruktur.
+
+\medskip
+\noindent
+
+Die Laufzeitumgebung der Microservice-Container ist Kubernetes, welches auf den Cloud-Providern \ac{AWS}, \ac{GCP} und \ac{Azure} als verwalteter Service gebucht wird.
+Kubernetes ist ein Container-Orchestrierungssystem, welches die Bereitstellung, Skalierung und Verwaltung von Containern ermöglicht und wird im Kapitel \ref{subsec:description:umfeld} genauer beschrieben.
+Die Microservices werden in den Programmiersprachen Java, Python und Golang entwickelt und in Container-Images verpackt, was die enthaltenen Programmzeilen, Bibliotheken und Abhängigkeiten kapselt und somit eine effiziente Bereitstellung, Skalierung und Unveränderbarkeit ermöglicht.
+
+\medskip
+\noindent
+
+Die implementierung mehrerer Cloud-Provicer ist notwendig, da die Microservices aufgrund von Kundenanforderungen auf verschiedenen Cloud-Providern bereitgestellt werden müssen.
+Ein Kunde kann beispielsweise die Bereitstellung seiner Microservices auf \ac{AWS} fordern, während ein anderer Kunde die Bereitstellung auf \ac{GCP} oder \ac{Azure} fordert.
+Die Wahl des Cloud-Providers ist für Kunden eine essenzielle Entscheidung, da Kunde komplexe Verträge mit den Cloud-Providern abschließen und diese nicht ohne weiteres wechseln können.
+So ist das Produkt der SDA SE eine Plattform, welche die Bereitstellung von Microservices auf verschiedenen Cloud-Providern ermöglicht, eine simultane Bereitstellung auf mehreren Cloud-Providern ist möglich, jedoch im Standard nicht vorgesehen.
+
 
 \subsection{Ziel}
 \label{subsec:description:ziel}

--- a/classicthesis-config.tex
+++ b/classicthesis-config.tex
@@ -81,7 +81,7 @@
 %\PassOptionsToPackage{spanish,es-lcroman}{babel}
 %\usepackage{babel}
 
-\usepackage{csquotes}
+%\usepackage[german=quotes]{csquotes}
 
 \PassOptionsToPackage{%
   %backend=biber,bibencoding=utf8, %instead of bibtex

--- a/frontbackmatter/Acronyms.tex
+++ b/frontbackmatter/Acronyms.tex
@@ -14,6 +14,15 @@
   \acro{DRY}{Don't Repeat Yourself}
   \acro{API}{Application Programming Interface}
   \acro{UML}{Unified Modeling Language}
+  \acro{AWS}{Amazon Web Services}
+  \acro{GCP}{Google Cloud Platform}
+  \acro{RBAC}{Role-Based Access Control}
+  \acro{DevOps}{Development and Operations}
+  \acro{Azure}{Microsoft Azure}
+  \acro{SDA}{Service Dominierte Architektur}
+  \acro{CI}{Continuous Integration}
+  \acro{CD}{Continuous Deployment}
+  \acro{DNS}{Domain Name System}
 \end{acronym}
 
 \cleardoublepage

--- a/hdathesis-config.tex
+++ b/hdathesis-config.tex
@@ -46,7 +46,8 @@
 % Packages with options that might require adjustments
 % ****************************************************************************************************
 
-%\PassOptionsToPackage{ngerman,american}{babel}   % change this to your language(s)
+\PassOptionsToPackage{ngerman}{babel}   % change this to your language(s)
 % Spanish languages need extra options in order to work with this template
 %\PassOptionsToPackage{spanish,es-lcroman}{babel}
 \usepackage{babel}
+\usepackage[autostyle=true,german=guillemets,maxlevel=3,german=quotes]{csquotes}


### PR DESCRIPTION
:sparkles: Tweaked language settings and enriched content in thesis template ℹ️ This commit alters language settings and expands the content in various sections of the thesis template. Changes include:
- Commenting out the use of csquotes package and replacing it with a German localized version
- Removed the XML declaration from misc.xml
- Added several new acronyms in Acronyms.tex
- Set the babel package to use the German language in hdathesis-config.tex
- Enhanced the content in the 'Projektbeschreibung' and 'Idee' sections of einleitung.tex These changes enhance the overall readability and completeness of the thesis template. :nerd_face: :book: